### PR TITLE
Agenda fixes

### DIFF
--- a/src/components/Calendar.css
+++ b/src/components/Calendar.css
@@ -1,6 +1,3 @@
-/*
- * TODO: Calendar should have rounded corners
- */
 .calendar {
     border: 1px solid #666;
     border-radius: 4px;

--- a/src/components/Calendar.css
+++ b/src/components/Calendar.css
@@ -3,4 +3,5 @@
  */
 .calendar {
     border: 1px solid #666;
+    border-radius: 4px;
 }

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -13,7 +13,7 @@ export default class Calendar extends PureComponent {
     }
 
     _renderTimeSlots() {
-        let {events, onSelectEvent} = this.props;
+        let {events, onSelectEvent, dateTime} = this.props;
 
         return new Array(HOURS_DAY)
             .fill(0)
@@ -23,6 +23,7 @@ export default class Calendar extends PureComponent {
 
                 return (
                     <TimeSlot
+                        dateTime={dateTime}
                         key={hour}
                         hour={hour}
                         events={filteredEvents}

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -13,7 +13,7 @@ export default class Calendar extends PureComponent {
     }
 
     _renderTimeSlots() {
-        let {events, onSelectEvent, dateTime} = this.props;
+        let {events, onSelectEvent} = this.props;
 
         return new Array(HOURS_DAY)
             .fill(0)
@@ -23,7 +23,6 @@ export default class Calendar extends PureComponent {
 
                 return (
                     <TimeSlot
-                        dateTime={dateTime}
                         key={hour}
                         hour={hour}
                         events={filteredEvents}

--- a/src/components/EventDetailOverlay.css
+++ b/src/components/EventDetailOverlay.css
@@ -1,7 +1,3 @@
-/*
- * TODO: Overlay container should have rounded corners
- */
-
 .event-detail-overlay {
     position: fixed;
     height: 100%;
@@ -69,16 +65,11 @@
     width: 1rem;
     vertical-align: sub;
     margin-left: 0.5rem;
-
-    /*
-     * TODO: Figure out how label color can match the event color instead of
-     * always being black
-     */
     background-color: #000;
 }
 
 .active {
-    box-shadow: 0 0 0.25rem 0 #51b1e0;
+    background-color: #51b1e0;
 }
 .sky {
     background-color: #d1e8f0;

--- a/src/components/EventDetailOverlay.css
+++ b/src/components/EventDetailOverlay.css
@@ -76,3 +76,19 @@
      */
     background-color: #000;
 }
+
+.active {
+    box-shadow: 0 0 0.25rem 0 #51b1e0;
+}
+.sky {
+    background-color: #d1e8f0;
+}
+.canary {
+    background-color: #fcf69a;
+}
+.rose {
+    background-color: #fcbbd2;
+}
+.shamrock {
+    background-color: #009e60;
+}

--- a/src/components/EventDetailOverlay.css
+++ b/src/components/EventDetailOverlay.css
@@ -27,6 +27,7 @@
     box-sizing: border-box;
     box-shadow: 0 0 0.25rem 0 #666;
     border: 1px solid #666;
+    border-radius: 4px;
     width: 100%;
     height: 100%;
     padding: 1rem;

--- a/src/components/EventDetailOverlay.css
+++ b/src/components/EventDetailOverlay.css
@@ -13,8 +13,9 @@
 @media (min-width: 50rem) {
     .event-detail-overlay {
         height: 12rem;
+        position: relative;
         width: 100%;
-        top: auto;
+        top: calc(100vh - 12rem);
         padding-bottom: 0;
     }
 }
@@ -29,6 +30,15 @@
     padding: 1rem;
     background-color: #fff;
     overflow: auto;
+    z-index: 2;
+}
+
+.event-detail-overlay__background {
+    position: fixed;
+    height: 100%;
+    top: 0;
+    left: 0;
+    z-index: 1;
 }
 
 .event-detail-overlay__close {

--- a/src/components/EventDetailOverlay.js
+++ b/src/components/EventDetailOverlay.js
@@ -39,7 +39,7 @@ export default class EventDetailOverlay extends PureComponent {
                     <div>
                         {displayDateTime}
                         <span
-                            className="event-detail-overlay__color"
+                            className={`event-detail-overlay__color ${color}`}
                             title={`Event label color: ${color}`}
                         />
                     </div>

--- a/src/components/EventDetailOverlay.js
+++ b/src/components/EventDetailOverlay.js
@@ -23,7 +23,9 @@ export default class EventDetailOverlay extends PureComponent {
         let endHourDisplay = getDisplayHour(endHour);
 
         let displayDateTime = `${displayDate} ${startHourDisplay} - ${endHourDisplay}`
-
+        document.addEventListener('keyup', (event) => {
+            if (event.keyCode === 27) this.props.onClose()
+        })
         // TODO: The event label color should match the event color
         // TODO: Add appropriate ARIA tags to overlay/dialog
         // TODO: Support clicking outside of the overlay to close it

--- a/src/components/EventDetailOverlay.js
+++ b/src/components/EventDetailOverlay.js
@@ -29,24 +29,29 @@ export default class EventDetailOverlay extends PureComponent {
         // TODO: Add appropriate ARIA tags to overlay/dialog
         // TODO: Support clicking outside of the overlay to close it
         return (
-            <section className="event-detail-overlay">
-                <div className="event-detail-overlay__container">
-                    <button
-                        className="event-detail-overlay__close"
-                        title="Close detail view"
-                        onClick={onClose}
-                    />
-                    <div>
-                        {displayDateTime}
-                        <span
-                            className={`event-detail-overlay__color ${color}`}
-                            title={`Event label color: ${color}`}
+            <section className="event-detail-overlay__background"
+                onClick={(e) => {
+                    if (e.target.className === "event-detail-overlay__background") onClose()
+                }}>
+                <div className="event-detail-overlay">
+                    <div className="event-detail-overlay__container">
+                        <button
+                            className="event-detail-overlay__close"
+                            title="Close detail view"
+                            onClick={onClose}
                         />
+                        <div>
+                            {displayDateTime}
+                            <span
+                                className={`event-detail-overlay__color ${color}`}
+                                title={`Event label color: ${color}`}
+                            />
+                        </div>
+                        <h1 className="event-detail-overlay__title">
+                            {title}
+                        </h1>
+                        <p>{description}</p>
                     </div>
-                    <h1 className="event-detail-overlay__title">
-                        {title}
-                    </h1>
-                    <p>{description}</p>
                 </div>
             </section>
         );

--- a/src/components/EventDetailOverlay.js
+++ b/src/components/EventDetailOverlay.js
@@ -26,10 +26,8 @@ export default class EventDetailOverlay extends PureComponent {
         document.addEventListener('keyup', (event) => {
             if (event.keyCode === 27) this.props.onClose()
         })
-        // TODO: The event label color should match the event color
         // TODO: Add appropriate ARIA tags to overlay/dialog
         // TODO: Support clicking outside of the overlay to close it
-        // TODO: Support clicking ESC to close it
         return (
             <section className="event-detail-overlay">
                 <div className="event-detail-overlay__container">

--- a/src/components/Page.css
+++ b/src/components/Page.css
@@ -1,8 +1,3 @@
-/*
- * TODO: page needs a gradient from white (top) to light gray (bottom)
- * TODO: On narrow screens the background shouldn't scroll when detail overlay is shown
- */
-
 .page {
     margin: 1rem;
     background-image: linear-gradient(to bottom, white, lightgrey);

--- a/src/components/Page.css
+++ b/src/components/Page.css
@@ -5,6 +5,7 @@
 
 .page {
     margin: 1rem;
+    background-image: linear-gradient(to bottom, white, lightgrey);
 }
 .page__header {
     margin-bottom: 1rem;

--- a/src/components/Page.css
+++ b/src/components/Page.css
@@ -6,6 +6,7 @@
 .page {
     margin: 1rem;
     background-image: linear-gradient(to bottom, white, lightgrey);
+    border-radius: 0 0 4px 4px;
 }
 .page__header {
     margin-bottom: 1rem;

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -48,10 +48,14 @@ export default class Page extends PureComponent {
     }
 
     _handlePrev() {
+        let previousDay = this.state.day - 86400000
+        this.setState({day: previousDay})
         // TODO: Update this.state.day to go back 1 day so previous button works
     }
 
     _handleNext() {
+        let nextDay = this.state.day + 86400000
+        this.setState({day: nextDay})
         // TODO: Update this.state.day to go forward 1 day so next button works
     }
 

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -85,7 +85,7 @@ export default class Page extends PureComponent {
                     onPrev={this._handlePrev.bind(this)}
                     onNext={this._handleNext.bind(this)}
                 />
-                <Calendar dateTime={dateTime} events={filteredEvents} onSelectEvent={this._handleSelectEvent.bind(this)} />
+                <Calendar events={filteredEvents} onSelectEvent={this._handleSelectEvent.bind(this)} />
                 {eventDetailOverlay}
             </div>
         );

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -39,10 +39,12 @@ export default class Page extends PureComponent {
 
     _handleSelectEvent(selectedEventId) {
         this.setState({selectedEventId});
+        document.body.classList.add('no-scroll')
     }
 
     _handleEventDetailOverlayClose() {
         this.setState({selectedEventId: undefined});
+        document.body.classList.remove('no-scroll')
     }
 
     _handlePrev() {

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -53,13 +53,11 @@ export default class Page extends PureComponent {
     _handlePrev() {
         let previousDay = this.state.day - 86400000
         this.setState({day: previousDay})
-        // TODO: Update this.state.day to go back 1 day so previous button works
     }
 
     _handleNext() {
         let nextDay = this.state.day + 86400000
         this.setState({day: nextDay})
-        // TODO: Update this.state.day to go forward 1 day so next button works
     }
 
     render() {

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -45,6 +45,9 @@ export default class Page extends PureComponent {
     _handleEventDetailOverlayClose() {
         this.setState({selectedEventId: undefined});
         document.body.classList.remove('no-scroll')
+        document.removeEventListener('keyup', (event) => {
+            if (event.keyCode === 27) this.props.onClose()
+        })
     }
 
     _handlePrev() {

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -58,6 +58,7 @@ export default class Page extends PureComponent {
         let filteredEvents = filterEventsByDay(events, day);
         let selectedEvent = getEventFromEvents(events, selectedEventId);
         let eventDetailOverlay;
+        const dateTime = getDisplayDate(day);
 
         if (selectedEvent) {
             eventDetailOverlay = (
@@ -74,11 +75,11 @@ export default class Page extends PureComponent {
                     <h1 className="page__title">Daily Agenda</h1>
                 </header>
                 <DayNavigator
-                    dateDisplay={getDisplayDate(day)}
+                    dateDisplay={dateTime}
                     onPrev={this._handlePrev.bind(this)}
                     onNext={this._handleNext.bind(this)}
                 />
-                <Calendar events={filteredEvents} onSelectEvent={this._handleSelectEvent.bind(this)} />
+                <Calendar dateTime={dateTime} events={filteredEvents} onSelectEvent={this._handleSelectEvent.bind(this)} />
                 {eventDetailOverlay}
             </div>
         );

--- a/src/components/TimeSlot.css
+++ b/src/components/TimeSlot.css
@@ -14,6 +14,9 @@
      * which causes a double border
      */
 }
+.time-slot:last-of-type {
+    border-bottom: 0;
+}
 .time-slot__hour-label {
     width: 4rem;
     text-align: right;

--- a/src/components/TimeSlot.css
+++ b/src/components/TimeSlot.css
@@ -1,18 +1,8 @@
-/**
- * TODO: Each time slot event should take up the full width and vertically stack
- * on top of each other. On larger screens, when there are multiple events for
- * a time slot, they should be evenly divided on the same row
- */
 .time-slot {
     display: flex;
     border-bottom: 1px solid #666;
     min-height: 3rem;
     box-sizing: border-box;
-
-    /**
-     * TODO: Figure out how not to have a bottom border on the last time-slot
-     * which causes a double border
-     */
 }
 .time-slot:last-of-type {
     border-bottom: 0;

--- a/src/components/TimeSlot.css
+++ b/src/components/TimeSlot.css
@@ -40,6 +40,10 @@
     min-width: 0;
 }
 
+.old-event {
+    opacity: 0.4;
+}
+
 @media screen and (min-width: 50rem) {
     /* Override styles for larger screens here */
     .time-slot__events {

--- a/src/components/TimeSlot.css
+++ b/src/components/TimeSlot.css
@@ -27,14 +27,19 @@
 .time-slot__events {
     padding: 0.5rem;
     flex: 1;
-
+    display: flex;
     overflow: hidden;
+    flex-direction: column;
 }
 .time-slot__event {
     margin: 0.5rem;
-    max-width: 100%;
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
 @media screen and (min-width: 50rem) {
     /* Override styles for larger screens here */
+    .time-slot__events {
+        flex-direction: row;
+    }
 }

--- a/src/components/TimeSlot.js
+++ b/src/components/TimeSlot.js
@@ -23,15 +23,23 @@ export default class TimeSlot extends PureComponent {
     }
 
     render() {
-        let {hour} = this.props;
+        // get dateDisplay split and point to hour
+        // if hour is ahead of timeslot hour change opacity
+
+        let {hour, dateTime} = this.props;
         let displayHour = getDisplayHour(hour);
+        let currentHour = parseInt(dateTime.split(' ')[4].split(':')[0], 10);
+        let timeSlotEventsClassList = ["time-slot__events"]
+        if (currentHour > hour) {
+            timeSlotEventsClassList.push(' old-event')
+        }
 
         return (
             <section className="time-slot">
                 <span className="time-slot__hour-label">
                     {displayHour}
                 </span>
-                <div className="time-slot__events">
+                <div className={`${timeSlotEventsClassList.join('')}`}>
                     {this._renderEvents()}
                 </div>
             </section>

--- a/src/components/TimeSlot.js
+++ b/src/components/TimeSlot.js
@@ -23,23 +23,15 @@ export default class TimeSlot extends PureComponent {
     }
 
     render() {
-        // get dateDisplay split and point to hour
-        // if hour is ahead of timeslot hour change opacity
-        
         let {hour} = this.props;
         let displayHour = getDisplayHour(hour);
-        let currentHour = new Date().getHours();
-        let timeSlotEventsClassList = ["time-slot__events"]
-        if (currentHour > hour) {
-            timeSlotEventsClassList.push(' old-event')
-        }
 
         return (
             <section className="time-slot">
                 <span className="time-slot__hour-label">
                     {displayHour}
                 </span>
-                <div className={`${timeSlotEventsClassList.join('')}`}>
+                <div className='time-slot__events'>
                     {this._renderEvents()}
                 </div>
             </section>

--- a/src/components/TimeSlot.js
+++ b/src/components/TimeSlot.js
@@ -25,10 +25,10 @@ export default class TimeSlot extends PureComponent {
     render() {
         // get dateDisplay split and point to hour
         // if hour is ahead of timeslot hour change opacity
-
-        let {hour, dateTime} = this.props;
+        
+        let {hour} = this.props;
         let displayHour = getDisplayHour(hour);
-        let currentHour = parseInt(dateTime.split(' ')[4].split(':')[0], 10);
+        let currentHour = new Date().getHours();
         let timeSlotEventsClassList = ["time-slot__events"]
         if (currentHour > hour) {
             timeSlotEventsClassList.push(' old-event')

--- a/src/components/TimeSlotEvent.css
+++ b/src/components/TimeSlotEvent.css
@@ -1,7 +1,3 @@
-/*
- * TODO: Time slot events should have rounded corners
- * TODO: Past events should display faded-out
- */
 .time-slot-event {
     display: block;
     cursor: pointer;

--- a/src/components/TimeSlotEvent.css
+++ b/src/components/TimeSlotEvent.css
@@ -11,7 +11,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    max-width: 100%;
+    width: 100%;
 }
 .time-slot-event::-moz-focus-inner {
   border: 0;

--- a/src/components/TimeSlotEvent.css
+++ b/src/components/TimeSlotEvent.css
@@ -6,6 +6,7 @@
     display: block;
     cursor: pointer;
     border: 1px solid transparent;
+    border-radius: 4px;
     padding: 0.5rem;
     font-size: 1rem;
     overflow: hidden;

--- a/src/components/TimeSlotEvent.js
+++ b/src/components/TimeSlotEvent.js
@@ -1,5 +1,6 @@
 import React, {PureComponent, PropTypes} from 'react';
 import {EVENT_PROP_TYPE} from './constants';
+import {MILLISECONDS_SECOND, SECONDS_MINUTE, MINUTES_HOUR} from '../utils/constants'
 
 import './TimeSlotEvent.css';
 
@@ -11,15 +12,22 @@ export default class TimeSlotEvent extends PureComponent {
 
     render() {
         let {
-            event: {title, color},
+            event: {title, color, start},
             onSelect,
         } = this.props;
-
-        // TODO: Need a way to determine that the event is in the past so that it
-        // can be displayed faded-out
+        let eventDate = new Date(start);
+        let now = Date.now()
+        let oneHour = MILLISECONDS_SECOND * SECONDS_MINUTE * MINUTES_HOUR;
+        let classes = [`time-slot-event time-slot-event--${color}`];
+        if (start < now) {
+                classes.push(' old-event')
+            if (now - start < oneHour && new Date(now).getHours() > eventDate.getHours()) {
+                classes.pop()
+            }
+        }
 
         return (
-            <button className={`time-slot-event time-slot-event--${color}`} onClick={onSelect}>
+            <button className={classes.join('')} onClick={onSelect}>
                 {title}
             </button>
         );

--- a/src/index.css
+++ b/src/index.css
@@ -10,7 +10,7 @@ h3 {
 body {
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;
-
+    background-image: linear-gradient(to bottom, white, lightgrey);
     color: #212121;
     font-family: "Helvetica Neue", "Calibri Light", Roboto, sans-serif;
     letter-spacing: 0.02em;

--- a/src/index.css
+++ b/src/index.css
@@ -15,3 +15,7 @@ body {
     font-family: "Helvetica Neue", "Calibri Light", Roboto, sans-serif;
     letter-spacing: 0.02em;
 }
+
+.no-scroll {
+    overflow: hidden;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -10,7 +10,7 @@ h3 {
 body {
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;
-    background-image: linear-gradient(to bottom, white, lightgrey);
+    
     color: #212121;
     font-family: "Helvetica Neue", "Calibri Light", Roboto, sans-serif;
     letter-spacing: 0.02em;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -3,6 +3,15 @@ const _HOUR_DISPLAY_MAP = [
     '12PM', '1PM', '2PM', '3PM', '4PM', '5PM', '6PM', '7PM', '8PM', '9PM', '10PM', '11PM',
 ]
 
+const _DATE_DAY_MAP = [
+    'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'
+]
+
+const _DATE_MONTH_MAP = [
+    'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September',
+    'October', 'November', 'December'
+]
+
 /**
  * Given a list of events and a date, filter the events down to those that
  * fall on the same day as the date
@@ -37,10 +46,10 @@ export const filterEventsByHour = (events, hour) => (
  */
 export const getDisplayDate = (timestamp) => {
     let date = new Date(timestamp);
-
+    let day = _DATE_DAY_MAP[date.getDay()]
+    let month = _DATE_MONTH_MAP[date.getMonth()]
     // TODO: Format the date like: "Tuesday, April 11, 2017"
-
-    return date.toString();
+    return `${day}, ${month} ${date.getDate()}, ${date.getFullYear()}`
 };
 
 /**

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -14,9 +14,7 @@ const _DATE_MONTH_MAP = [
  * @param {Date} timestamp - The timestamp representing the day to match
  * @returns {array}
  */
-export const filterEventsByDay = (events, timestamp) => {
-    // TODO: Implement day filtering!
-    
+export const filterEventsByDay = (events, timestamp) => { 
     return events.filter(event => {
         let eventDate = new Date(event.start)
         let targetDate = new Date(timestamp)
@@ -49,7 +47,6 @@ export const getDisplayDate = (timestamp) => {
     let date = new Date(timestamp);
     let day = _DATE_DAY_MAP[date.getDay()]
     let month = _DATE_MONTH_MAP[date.getMonth()]
-    // TODO: Format the date like: "Tuesday, April 11, 2017"
     return `${day}, ${month} ${date.getDate()}, ${date.getFullYear()}`
 };
 
@@ -58,7 +55,6 @@ export const getDisplayDate = (timestamp) => {
  * @param {number} hour - The hour
  * @returns {string}
  */
-// TODO: Implement using a more programmatic approach instead of map
 export const getDisplayHour = (hour) => {
     if (hour === 0) return '12AM'
     else if (hour >= 1 && hour <= 11) return `${hour}AM`

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -21,8 +21,14 @@ const _DATE_MONTH_MAP = [
  */
 export const filterEventsByDay = (events, timestamp) => {
     // TODO: Implement day filtering!
-
-    return events;
+    
+    return events.filter(event => {
+        let eventDate = new Date(event.start)
+        let targetDate = new Date(timestamp)
+        return eventDate.getFullYear() === targetDate.getFullYear() &&
+               eventDate.getMonth() === targetDate.getMonth() &&
+               eventDate.getDate() === targetDate.getDate()
+    })
 }
 
 /**

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,8 +1,3 @@
-const _HOUR_DISPLAY_MAP = [
-    '12AM', '1AM', '2AM', '3AM', '4AM', '5AM', '6AM', '7AM', '8AM', '9AM', '10AM', '11AM',
-    '12PM', '1PM', '2PM', '3PM', '4PM', '5PM', '6PM', '7PM', '8PM', '9PM', '10PM', '11PM',
-]
-
 const _DATE_DAY_MAP = [
     'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'
 ]
@@ -64,8 +59,13 @@ export const getDisplayDate = (timestamp) => {
  * @returns {string}
  */
 // TODO: Implement using a more programmatic approach instead of map
-export const getDisplayHour = (hour) => _HOUR_DISPLAY_MAP[hour]
-
+export const getDisplayHour = (hour) => {
+    if (hour === 0) return '12AM'
+    else if (hour >= 1 && hour <= 11) return `${hour}AM`
+    else if (hour === 12) return `${hour}PM`
+    else if (hour >= 13 && hour <= 23) return `${hour - 12}PM`
+    else console.error('error with hour', hour)
+}
 /**
  * Given a list of events, returns the event object whose id matches the specified eventId
  * @param {array} events - List of event objects


### PR DESCRIPTION
**Adds various CSS and JS fixes to the Agenda feature.**

- [x] [CSS] Each time slot event should take up the full width and vertically stack on top of each other. On larger screens, when there are multiple events for a time slot, they should be evenly divided on the same row.
- [x] [CSS] Entire page background needs a gradient from white (top) to light gray (bottom)

- [x] [CSS] Add rounded corners on overall grid, time slot events, and event detail overlay

- [x] [CSS] Event color indicator in overlay (small square next to the time time) should match the event color

- [x] [CSS] Remove double border at bottom of the 11PM timeslot

- [x] [JS/CSS] Past events should display faded out

- [x] [JS/CSS] Prevent scrolling in the background when event detail shows

- [x] [JS] Buttons to navigate to previous/next day do not work

- [x] [JS] Implement filtering by day, so that events only appear on their respective dates

- [x] [JS] Improve naively implemented getDisplayDate helper function

- [x] [JS] Improve naively implemented getDisplayHour helper function

- [x] [JS] Hitting ESC key should close event details overlay

**TODO:**

- [x] [JS] Clicking outside of an open event details overlay should close the overlay

- [ ] [JS/HTML] Event detail overlay is missing proper ARIA attributes